### PR TITLE
Moved ChannelNode creation into get_channel

### DIFF
--- a/ka_sushi_chef.py
+++ b/ka_sushi_chef.py
@@ -50,10 +50,22 @@ class KASushiChef(SushiChef):
 
     def get_channel(self, *args, **kwargs):
 
-        return self.construct_channel(*args, **kwargs)
+        lang_code = kwargs['lang']
+
+        channel = ChannelNode(
+            source_id="KA ({0})".format(lang_code),
+            source_domain="khanacademy.org",
+            title="Khan Academy ({0})".format(lang_code),
+            description='Khan Academy content for the {0} language.'.format(lang_code),
+            thumbnail="https://cdn.kastatic.org/images/khan-logo-vertical-transparent.png",
+        )
+
+        return channel
+
 
     def construct_channel(self, *args, **kwargs):
 
+        channel = self.get_channel(*args, **kwargs)
         lang = kwargs['lang']
         subprocess.run('make {0}'.format(lang), shell=True, check=True)
 
@@ -68,21 +80,13 @@ class KASushiChef(SushiChef):
         for item in assessment_data:
             assessment_dict[item['id']] = item
 
-        tree = _build_tree(node_data, assessment_dict, lang)
+        tree = _build_tree(channel, node_data, assessment_dict, lang)
         clean_nodes(tree)
 
         return tree
 
 
-def _build_tree(node_data, assessment_dict, lang_code):
-
-    channel = ChannelNode(
-        source_id="KA ({0})".format(lang_code),
-        source_domain="khanacademy.org",
-        title="Khan Academy ({0})".format(lang_code),
-        description='Khan Academy content for the {0} language.'.format(lang_code),
-        thumbnail="https://cdn.kastatic.org/images/khan-logo-vertical-transparent.png",
-    )
+def _build_tree(channel, node_data, assessment_dict, lang_code):
 
     # recall KA api for exercises dict
     ka_exercises = requests.get('http://www.khanacademy.org/api/v1/exercises').json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,6 @@ six==1.10.0
 ujson==1.33
 decorator==4.0.10
 httplib2==0.9.2
-html2text
+html2text==2016.9.19
+le-utils==0.0.9rc24
+ricecooker>=0.6.2


### PR DESCRIPTION
Small changes to avoid calling `_build_tree` twice. The first time `get_channel` is called to get the channel metadata (see [here](https://github.com/learningequality/ricecooker/blob/master/ricecooker/commands.py#L94)), the second time is within `construct_channel`.

The `lang_code` used in the chef code  is the same as the `lang` option passed on the command line, right? If so this should work.